### PR TITLE
Add limit option + fields support (bump to v0.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Self-sufficient fork of [node-tags](https://travis-ci.org/atom/node-ctags) prebu
 
 `ctags-prebuilt` includes prebuilt binaries of [node-tags](https://travis-ci.org/atom/node-ctags) for Mac and Linux for major versions of node.js and io.js. It's meant for use in [Atom packages](https://atom.io/packages) where your end-user might not have a proper build toolchain.
 
-This module isn't meant to be built by the end-user. It doesn't include the necessary files for it. 
+This module isn't meant to be built by the end-user. It doesn't include the necessary files for it.
 
 ## Building
 
@@ -45,6 +45,8 @@ Get all tags matching the tag specified from the tags file at the path.
     (default: `false`)
   * `partialMatch` - `true` to include tags that partially match the given tag
     (default: `false`)
+  * `limit` - maximum number of matches to return. Should be a positive integer.
+    (default: unlimited)
 
 * `callback` - The function to call when complete with an error as the first
              argument and an array containing objects that have `name` and

--- a/README.md
+++ b/README.md
@@ -49,9 +49,14 @@ Get all tags matching the tag specified from the tags file at the path.
     (default: unlimited)
 
 * `callback` - The function to call when complete with an error as the first
-             argument and an array containing objects that have `name` and
-             `file` keys and optionally a `pattern` key if the tag file
-             specified contains tag patterns.
+             argument and an array containing tag objects. Each tag object contains:
+
+  * `name` - name of the tag
+  * `file` - location of the tag
+  * `kind` - kind of the tag (see `ctags --list-kinds`)
+  * `lineNumber` - line number of the tag in `file` (defaults to 0 if not provided)
+  * `pattern` (optional) - pattern to search for in `file` (only if provided in tag file)
+  * `fields` (optional) - object with string values; extra fields for the tag (only if provided in tag file)
 
 #### Example
 

--- a/lib/ctags.js
+++ b/lib/ctags.js
@@ -22,9 +22,13 @@ exports.findTags = function(tagsFilePath, tag, options, callback) {
 
   var caseInsensitive = options ? options.caseInsensitive : null;
   var partialMatch = options ? options.partialMatch : null;
+  var limit = options ? options.limit : null;
+  if (limit != null && (!(typeof limit === "number") || limit <= 0)) {
+    throw new TypeError('limit must be a positive integer');
+  }
   var tagsWrapper = new Tags(tagsFilePath);
 
-  tagsWrapper.findTags(tag, partialMatch, caseInsensitive, function(error, tags) {
+  tagsWrapper.findTags(tag, partialMatch, caseInsensitive, limit, function(error, tags) {
     tagsWrapper.end();
     callback(error, tags);
   });

--- a/spec/ctags-fields-spec.js
+++ b/spec/ctags-fields-spec.js
@@ -1,0 +1,55 @@
+'use strict';
+
+var path = require('path');
+var ctags = require('../');
+
+var tagsFile = path.join(__dirname, 'fixtures', 'fields-tags');
+
+describe('ctags.createReadStream(tagsFileWithFields)', function() {
+  it('returns a stream that emits data and end events', function() {
+    var endHandler, stream, tags;
+    stream = ctags.createReadStream(tagsFile);
+    tags = [];
+    stream.on('data', function(chunk) {
+      return tags = tags.concat(chunk);
+    });
+    endHandler = jasmine.createSpy('endHandler');
+    stream.on('end', endHandler);
+    waitsFor(function() {
+      return endHandler.callCount === 1;
+    });
+    return runs(function() {
+      expect(tags.length).toBe(4);
+      expect(tags[0].file).toBe('tagged.js');
+      expect(tags[0].name).toBe('callMeMaybe');
+      expect(tags[0].pattern).toBe('/^function callMeMaybe() {$/');
+      expect(tags[0].kind).toBe('f');
+      expect(tags[0].fields).toEqual({
+        "class": 'TestClass',
+        extra: 'test'
+      });
+      expect(tags[1].file).toBe('tagged-duplicate.js');
+      expect(tags[1].name).toBe('duplicate');
+      expect(tags[1].pattern).toBe('/^function duplicate() {$/');
+      expect(tags[1].kind).toBe('f');
+      expect(tags[1].fields).toEqual({
+        test: 'spaces are fine',
+        test2: 'more spaces'
+      });
+      expect(tags[2].file).toBe('tagged.js');
+      expect(tags[2].name).toBe('duplicate');
+      expect(tags[2].pattern).toBe('/^function duplicate() {$/');
+      expect(tags[2].kind).toBe('f');
+      expect(tags[2].fields).toEqual({
+        'field name': '1'
+      });
+      expect(tags[3].file).toBe('tagged.js');
+      expect(tags[3].name).toBe('thisIsCrazy');
+      expect(tags[3].pattern).toBe('/^var thisIsCrazy = true;$/');
+      expect(tags[3].kind).toBe('v');
+      return expect(tags[3].fields).toEqual({
+        emptyField: ''
+      });
+    });
+  });
+});

--- a/spec/ctags-spec.js
+++ b/spec/ctags-spec.js
@@ -80,6 +80,24 @@ describe('ctags.findTags(name, options, callback)', function() {
       });
     });
   });
+
+  describe('when limit is set', function() {
+    it('returns the correct number of tags', function() {
+      var callback = jasmine.createSpy('callback');
+      ctags.findTags(tagsFile, 'dup', {partialMatch: true, limit: 1}, callback);
+
+      waitsFor(function() {
+        return callback.callCount === 1;
+      });
+
+      runs(function() {
+        var tags = callback.argsForCall[0][1];
+        expect(callback.argsForCall[0][0]).toBeFalsy();
+        expect(tags.length).toBe(1);
+        expect(tags[0].name).toBe('duplicate');
+      });
+    });
+  });
 });
 
 describe('ctags.createReadStream(tagsFilePath)', function() {

--- a/spec/fixtures/fields-tags
+++ b/spec/fixtures/fields-tags
@@ -1,0 +1,10 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
+!_TAG_PROGRAM_NAME	Exuberant Ctags	//
+!_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
+!_TAG_PROGRAM_VERSION	5.8	//
+callMeMaybe	tagged.js	/^function callMeMaybe() {$/;"	f	class:TestClass	extra:test
+duplicate	tagged-duplicate.js	/^function duplicate() {$/;"	f	test:spaces are fine	test2:more spaces
+duplicate	tagged.js	/^function duplicate() {$/;"	f	field name:1
+thisIsCrazy	tagged.js	/^var thisIsCrazy = true;$/;"	v	emptyField:

--- a/src/tag-finder.cc
+++ b/src/tag-finder.cc
@@ -15,20 +15,7 @@ void TagFinder::HandleOKCallback() {
 
   Local<Array> array = Nan::New<Array>(matches.size());
   for (size_t i = 0; i < matches.size(); i++) {
-    Local<Object> tagObject = Nan::New<Object>();
-    tagObject->Set(Nan::New<String>("name").ToLocalChecked(),
-                   Nan::New<String>(matches[i].name.data()).ToLocalChecked());
-    tagObject->Set(Nan::New<String>("file").ToLocalChecked(),
-                   Nan::New<String>(matches[i].file.data()).ToLocalChecked());
-    tagObject->Set(Nan::New<String>("kind").ToLocalChecked(),
-                   Nan::New<String>(matches[i].kind.data()).ToLocalChecked());
-    tagObject->Set(Nan::New<String>("lineNumber").ToLocalChecked(),
-                   Nan::New<Integer>((int32_t)matches[i].lineNumber));
-    if (matches[i].pattern.length() > 0)
-      tagObject->Set(
-          Nan::New<String>("pattern").ToLocalChecked(),
-          Nan::New<String>(matches[i].pattern.data()).ToLocalChecked());
-    array->Set(i, tagObject);
+    array->Set(i, matches[i].toV8Object());
   }
 
   Local<Value> argv[] = { Nan::Null(), array };

--- a/src/tag-finder.cc
+++ b/src/tag-finder.cc
@@ -4,7 +4,8 @@ void TagFinder::Execute() {
   tagEntry entry;
   if (tagsFind(file, &entry, tag.data(), options) == TagSuccess) {
     matches.push_back(Tag(entry));
-    while (tagsFindNext(file, &entry) == TagSuccess)
+    while ((limit == 0 || matches.size() < limit) &&
+           tagsFindNext(file, &entry) == TagSuccess)
       matches.push_back(Tag(entry));
   }
 }

--- a/src/tag-finder.h
+++ b/src/tag-finder.h
@@ -11,8 +11,16 @@ using namespace v8;
 
 class TagFinder : public Nan::AsyncWorker {
  public:
-  TagFinder(Nan::Callback *callback, std::string tag, int options, tagFile *file)
-    : Nan::AsyncWorker(callback), options(options), tag(tag), file(file) {}
+  TagFinder(Nan::Callback* callback,
+            std::string tag,
+            int options,
+            size_t limit,
+            tagFile* file)
+      : Nan::AsyncWorker(callback),
+        options(options),
+        limit(limit),
+        tag(tag),
+        file(file) {}
 
   ~TagFinder() {}
 
@@ -21,6 +29,7 @@ class TagFinder : public Nan::AsyncWorker {
 
  private:
   int options;
+  size_t limit;
   std::string tag;
   std::vector< Tag > matches;
   tagFile *file;

--- a/src/tag-reader.cc
+++ b/src/tag-reader.cc
@@ -17,23 +17,7 @@ void TagReader::HandleOKCallback() {
 
   Local<Array> array = Nan::New<Array>(tags.size());
   for (size_t i = 0; i < tags.size(); i++) {
-    Local<Object> tagObject = Nan::New<Object>();
-    tagObject->Set(
-        Nan::New<String>("name").ToLocalChecked(),
-        Nan::New<String>(tags[i].name.data()).ToLocalChecked());
-    tagObject->Set(
-        Nan::New<String>("file").ToLocalChecked(),
-        Nan::New<String>(tags[i].file.data()).ToLocalChecked());
-    tagObject->Set(
-        Nan::New<String>("kind").ToLocalChecked(),
-        Nan::New<String>(tags[i].kind.data()).ToLocalChecked());
-    tagObject->Set(Nan::New<String>("lineNumber").ToLocalChecked(),
-                   Nan::New<Integer>((int32_t)tags[i].lineNumber));
-    if (tags[i].pattern.length() > 0)
-      tagObject->Set(
-          Nan::New<String>("pattern").ToLocalChecked(),
-          Nan::New<String>(tags[i].pattern.data()).ToLocalChecked());
-    array->Set(i, tagObject);
+    array->Set(i, tags[i].toV8Object());
   }
 
   Local<Value> argv[] = { Nan::Null(), array };

--- a/src/tag.h
+++ b/src/tag.h
@@ -2,7 +2,11 @@
 #define SRC_TAG_H_
 
 #include <string>
+#include <utility>
+#include <vector>
+#include "nan.h"
 #include "readtags.h"
+#include "v8.h"
 
 class Tag {
  public:
@@ -12,6 +16,38 @@ class Tag {
     kind = entry.kind != NULL ? entry.kind : "";
     pattern = entry.address.pattern != NULL ? entry.address.pattern : "";
     lineNumber = entry.address.lineNumber;
+    for (size_t i = 0; i < entry.fields.count; i++) {
+      fields.push_back(std::make_pair(
+        std::string(entry.fields.list[i].key),
+        std::string(entry.fields.list[i].value)
+      ));
+    }
+  }
+
+  v8::Local<v8::Object> toV8Object() {
+    using namespace v8;
+
+    Local<Object> tagObject = Nan::New<Object>();
+    tagObject->Set(Nan::New<String>("name").ToLocalChecked(),
+                   Nan::New<String>(name.data()).ToLocalChecked());
+    tagObject->Set(Nan::New<String>("file").ToLocalChecked(),
+                   Nan::New<String>(file.data()).ToLocalChecked());
+    tagObject->Set(Nan::New<String>("kind").ToLocalChecked(),
+                   Nan::New<String>(kind.data()).ToLocalChecked());
+    tagObject->Set(Nan::New<String>("lineNumber").ToLocalChecked(),
+                   Nan::New<Integer>((int32_t)lineNumber));
+    if (pattern.length() > 0)
+      tagObject->Set(Nan::New<String>("pattern").ToLocalChecked(),
+                     Nan::New<String>(pattern.data()).ToLocalChecked());
+    if (fields.size() > 0) {
+      Local<Object> fieldsObj = Nan::New<Object>();
+      for (size_t j = 0; j < fields.size(); j++) {
+        fieldsObj->Set(Nan::New<String>(fields[j].first).ToLocalChecked(),
+                       Nan::New<String>(fields[j].second).ToLocalChecked());
+      }
+      tagObject->Set(Nan::New<String>("fields").ToLocalChecked(), fieldsObj);
+    }
+    return tagObject;
   }
 
   std::string name;
@@ -19,6 +55,7 @@ class Tag {
   std::string kind;
   std::string pattern;
   unsigned long lineNumber;
+  std::vector<std::pair<std::string, std::string> > fields;
 };
 
 #endif  // SRC_TAG_H_

--- a/src/tags.cc
+++ b/src/tags.cc
@@ -56,8 +56,9 @@ NAN_METHOD(Tags::FindTags) {
   else
     options |= TAG_OBSERVECASE;
 
-  Nan::Callback *callback = new Nan::Callback(info[3].As<Function>());
-  Nan::AsyncQueueWorker(new TagFinder(callback, tag, options, tagFile));
+  size_t limit = info[3]->IntegerValue();
+  Nan::Callback *callback = new Nan::Callback(info[4].As<Function>());
+  Nan::AsyncQueueWorker(new TagFinder(callback, tag, options, limit, tagFile));
   info.GetReturnValue().SetUndefined();
 }
 


### PR DESCRIPTION
I made the corresponding PRs back to the main repo:

limit option: https://github.com/atom/node-ctags/pull/12
field support: https://github.com/atom/node-ctags/pull/13

Had to do some minor customizations to work with this repo, but here they are. Specs are working and hopefully it builds on Travis.